### PR TITLE
fix(components): dynamic icon loading

### DIFF
--- a/src/components/DynamicIcon/index.tsx
+++ b/src/components/DynamicIcon/index.tsx
@@ -49,6 +49,7 @@ const DynamicIcon = memo(({ name, size, ...rest }: DynamicIconProps) => {
           'size-4': size === 16,
           'size-6': size === 24,
           'size-10': size === 40,
+          'size-6': !size,
         },
       )}
     >

--- a/src/components/DynamicIcon/index.tsx
+++ b/src/components/DynamicIcon/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { customIconImports, IconSize } from '@/icons';
+import { cn } from '@/utilities/cn';
 import dynamicIconImports from 'lucide-react/dynamicIconImports';
 import dynamic from 'next/dynamic';
 import { memo } from 'react';
@@ -14,14 +15,14 @@ type ReactComponent = React.FC<{ className?: string; size?: IconSize }>;
 // Initialize dynamic components
 const iconComponents = {} as Record<IconNames, ReactComponent>;
 
-// Load Lucide Icons
+// Load Lucide Icons with a loading skeleton to avoid jarring pop-in
 for (const name of Object.keys(dynamicIconImports) as LucideIconNames[]) {
   iconComponents[name] = dynamic(dynamicIconImports[name], {
     ssr: false,
   }) as ReactComponent;
 }
 
-// Load Custom Icons
+// Load Custom Icons with a loading skeleton to avoid jarring pop-in
 for (const name of Object.keys(customIconImports) as CustomIconNames[]) {
   iconComponents[name] = dynamic(customIconImports[name], {
     ssr: false,
@@ -35,14 +36,25 @@ type DynamicIconProps = {
   size?: IconSize;
 };
 
-const DynamicIcon = memo(({ name, ...props }: DynamicIconProps) => {
-  if (!name || !(name in iconComponents)) {
-    return null;
-  }
+const DynamicIcon = memo(({ name, size, ...rest }: DynamicIconProps) => {
+  if (!name || !(name in iconComponents)) return null;
 
   const Icon = iconComponents[name as IconNames];
 
-  return <Icon {...props} />;
+  return (
+    <span
+      className={cn(
+        'inline-block empty:rounded-sm empty:bg-njsig-neutral-primary/8 empty:animate-pulse',
+        {
+          'size-4': size === 16,
+          'size-6': size === 24,
+          'size-10': size === 40,
+        },
+      )}
+    >
+      <Icon size={size} {...rest} />
+    </span>
+  );
 });
 
 DynamicIcon.displayName = 'DynamicIcon';

--- a/src/components/DynamicIcon/index.tsx
+++ b/src/components/DynamicIcon/index.tsx
@@ -15,14 +15,14 @@ type ReactComponent = React.FC<{ className?: string; size?: IconSize }>;
 // Initialize dynamic components
 const iconComponents = {} as Record<IconNames, ReactComponent>;
 
-// Load Lucide Icons with a loading skeleton to avoid jarring pop-in
+// Load Lucide Icons
 for (const name of Object.keys(dynamicIconImports) as LucideIconNames[]) {
   iconComponents[name] = dynamic(dynamicIconImports[name], {
     ssr: false,
   }) as ReactComponent;
 }
 
-// Load Custom Icons with a loading skeleton to avoid jarring pop-in
+// Load Custom Icons
 for (const name of Object.keys(customIconImports) as CustomIconNames[]) {
   iconComponents[name] = dynamic(customIconImports[name], {
     ssr: false,


### PR DESCRIPTION
add a wrapper on dynamic icons to prevent layout shift and display a skeleton while `:empty`