### PR TITLE
fix: publishedAt now updates properly

### DIFF
--- a/src/collections/Documents.ts
+++ b/src/collections/Documents.ts
@@ -59,8 +59,9 @@ export const Documents: CollectionConfig = {
       },
     },
     {
-      name: 'updatedAt',
+      name: 'lastUpdatedAt',
       type: 'date',
+      virtual: 'updatedAt',
       admin: {
         position: 'sidebar',
         readOnly: true,

--- a/src/collections/Documents.ts
+++ b/src/collections/Documents.ts
@@ -41,6 +41,15 @@ export const Documents: CollectionConfig = {
       collection: 'events',
       on: 'resources.resource.document',
     },
+    // Sidebar Fields
+    {
+      name: 'fileType',
+      type: 'text',
+      admin: {
+        position: 'sidebar',
+        readOnly: true,
+      },
+    },
     {
       name: 'publishedAt',
       type: 'date',
@@ -50,8 +59,8 @@ export const Documents: CollectionConfig = {
       },
     },
     {
-      name: 'fileType',
-      type: 'text',
+      name: 'updatedAt',
+      type: 'date',
       admin: {
         position: 'sidebar',
         readOnly: true,

--- a/src/collections/Events/index.ts
+++ b/src/collections/Events/index.ts
@@ -387,8 +387,9 @@ export const Events: CollectionConfig<'events'> = {
       },
     },
     {
-      name: 'updatedAt',
+      name: 'lastUpdatedAt',
       type: 'date',
+      virtual: 'updatedAt',
       admin: {
         position: 'sidebar',
         readOnly: true,

--- a/src/collections/Events/index.ts
+++ b/src/collections/Events/index.ts
@@ -386,6 +386,14 @@ export const Events: CollectionConfig<'events'> = {
         readOnly: true,
       },
     },
+    {
+      name: 'updatedAt',
+      type: 'date',
+      admin: {
+        position: 'sidebar',
+        readOnly: true,
+      },
+    },
   ],
   defaultSort: '-startDate',
   hooks: {

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -113,8 +113,9 @@ export const Pages: CollectionConfig<'pages'> = {
       },
     },
     {
-      name: 'updatedAt',
+      name: 'lastUpdatedAt',
       type: 'date',
+      virtual: 'updatedAt',
       admin: {
         position: 'sidebar',
         readOnly: true,

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -80,7 +80,7 @@ export const Pages: CollectionConfig<'pages'> = {
         },
       ],
     },
-    ...slugField(),
+    // Sidebar Fields
     createParentField('pages', {
       filterOptions: ({ id }) => ({
         id: { not_equals: id }, // Prevent self reference
@@ -103,6 +103,7 @@ export const Pages: CollectionConfig<'pages'> = {
         ],
       },
     }),
+    ...slugField(),
     {
       name: 'publishedAt',
       type: 'date',
@@ -111,12 +112,23 @@ export const Pages: CollectionConfig<'pages'> = {
         readOnly: true,
       },
     },
+    {
+      name: 'updatedAt',
+      type: 'date',
+      admin: {
+        position: 'sidebar',
+        readOnly: true,
+      },
+    },
+    // Breadcrumbs Field
+    // This must be at the top level per the Nested Docs plugin requirements, but we can conditionally hide it in the UI since it's not relevant for all page types
     createBreadcrumbsField('pages', {
       admin: {
         description: 'Breadcrumbs are generated based on the page hierarchy.',
         condition: (_, siblingData) => siblingData.layout?.template !== 'navOnly',
       },
     }),
+    // Hidden Fields
     {
       name: 'template',
       type: 'text',
@@ -136,6 +148,7 @@ export const Pages: CollectionConfig<'pages'> = {
       },
     },
   ],
+  defaultSort: 'title',
   hooks: {
     beforeChange: [populatePublishedAtHook],
     afterChange: [revalidatePageHook],

--- a/src/collections/hooks/populatePublishedAtHook.ts
+++ b/src/collections/hooks/populatePublishedAtHook.ts
@@ -21,7 +21,11 @@ export const populatePublishedAtHook: CollectionBeforeChangeHook = ({
     const now = new Date();
 
     // Set publishedAt when transitioning to published status
-    if (data._status === 'published' && originalDoc?._status !== 'published') {
+    if (
+      data._status === 'published' &&
+      originalDoc?._status !== 'published' &&
+      !originalDoc?.publishedAt
+    ) {
       return {
         ...data,
         publishedAt: now,
@@ -29,12 +33,14 @@ export const populatePublishedAtHook: CollectionBeforeChangeHook = ({
     }
 
     // Set to null when becoming unpublished
-    if (data._status !== 'published') {
-      return {
-        ...data,
-        publishedAt: null,
-      };
-    }
+    // This block seems to be clearing the publishedAt date when a new draft is created from a published document, this is not desired.
+    // We want to maintain the original publishedAt date even if the document changes.
+    // if (data._status !== 'published') {
+    //   return {
+    //     ...data,
+    //     publishedAt: null,
+    //   };
+    // }
   }
 
   return data;

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -413,10 +413,11 @@ export interface Page {
     image?: (string | null) | Media;
     description?: string | null;
   };
+  parent?: (string | null) | Page;
   slug?: string | null;
   slugLock?: boolean | null;
-  parent?: (string | null) | Page;
   publishedAt?: string | null;
+  updatedAt: string;
   /**
    * Breadcrumbs are generated based on the page hierarchy.
    */
@@ -430,7 +431,6 @@ export interface Page {
     | null;
   template?: string | null;
   folder?: (string | null) | FolderInterface;
-  updatedAt: string;
   createdAt: string;
   deletedAt?: string | null;
   _status?: ('draft' | 'published') | null;
@@ -1066,11 +1066,11 @@ export interface Document {
     hasNextPage?: boolean;
     totalDocs?: number;
   };
-  publishedAt?: string | null;
   fileType?: string | null;
+  publishedAt?: string | null;
+  updatedAt: string;
   prefix?: string | null;
   folder?: (string | null) | FolderInterface;
-  updatedAt: string;
   createdAt: string;
   deletedAt?: string | null;
   url?: string | null;
@@ -1639,10 +1639,11 @@ export interface PagesSelect<T extends boolean = true> {
         image?: T;
         description?: T;
       };
+  parent?: T;
   slug?: T;
   slugLock?: T;
-  parent?: T;
   publishedAt?: T;
+  updatedAt?: T;
   breadcrumbs?:
     | T
     | {
@@ -1653,7 +1654,6 @@ export interface PagesSelect<T extends boolean = true> {
       };
   template?: T;
   folder?: T;
-  updatedAt?: T;
   createdAt?: T;
   deletedAt?: T;
   _status?: T;
@@ -1875,11 +1875,11 @@ export interface MediaSelect<T extends boolean = true> {
 export interface DocumentsSelect<T extends boolean = true> {
   title?: T;
   relatedEvents?: T;
-  publishedAt?: T;
   fileType?: T;
+  publishedAt?: T;
+  updatedAt?: T;
   prefix?: T;
   folder?: T;
-  updatedAt?: T;
   createdAt?: T;
   deletedAt?: T;
   url?: T;

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -417,7 +417,7 @@ export interface Page {
   slug?: string | null;
   slugLock?: boolean | null;
   publishedAt?: string | null;
-  updatedAt: string;
+  lastUpdatedAt?: string | null;
   /**
    * Breadcrumbs are generated based on the page hierarchy.
    */
@@ -431,6 +431,7 @@ export interface Page {
     | null;
   template?: string | null;
   folder?: (string | null) | FolderInterface;
+  updatedAt: string;
   createdAt: string;
   deletedAt?: string | null;
   _status?: ('draft' | 'published') | null;
@@ -857,6 +858,7 @@ export interface Event {
   slug?: string | null;
   slugLock?: boolean | null;
   publishedAt?: string | null;
+  lastUpdatedAt?: string | null;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;
@@ -1068,9 +1070,10 @@ export interface Document {
   };
   fileType?: string | null;
   publishedAt?: string | null;
-  updatedAt: string;
+  lastUpdatedAt?: string | null;
   prefix?: string | null;
   folder?: (string | null) | FolderInterface;
+  updatedAt: string;
   createdAt: string;
   deletedAt?: string | null;
   url?: string | null;
@@ -1643,7 +1646,7 @@ export interface PagesSelect<T extends boolean = true> {
   slug?: T;
   slugLock?: T;
   publishedAt?: T;
-  updatedAt?: T;
+  lastUpdatedAt?: T;
   breadcrumbs?:
     | T
     | {
@@ -1654,6 +1657,7 @@ export interface PagesSelect<T extends boolean = true> {
       };
   template?: T;
   folder?: T;
+  updatedAt?: T;
   createdAt?: T;
   deletedAt?: T;
   _status?: T;
@@ -1771,6 +1775,7 @@ export interface EventsSelect<T extends boolean = true> {
   slug?: T;
   slugLock?: T;
   publishedAt?: T;
+  lastUpdatedAt?: T;
   updatedAt?: T;
   createdAt?: T;
   _status?: T;
@@ -1877,9 +1882,10 @@ export interface DocumentsSelect<T extends boolean = true> {
   relatedEvents?: T;
   fileType?: T;
   publishedAt?: T;
-  updatedAt?: T;
+  lastUpdatedAt?: T;
   prefix?: T;
   folder?: T;
+  updatedAt?: T;
   createdAt?: T;
   deletedAt?: T;
   url?: T;


### PR DESCRIPTION
- Fixes the `publishedAt` hook so it no longer updates with every change.
- Updates Page, Document, and Event sidebars.