### PR TITLE
feat(block): section column widths

### DIFF
--- a/src/blocks/EmphasizedList/Component.tsx
+++ b/src/blocks/EmphasizedList/Component.tsx
@@ -21,7 +21,7 @@ export const EmphasizedListBlock: React.FC<EmphasizedListBlockProps> = ({
               <Triangle />
               <h3 className="text-xl lg:text-2xl font-medium">{item.title}</h3>
             </div>
-            <p className="my-4 pl-7 lg:pl-10 lg:text-lg">{item.content}</p>
+            <p className="my-4 pl-7 prose lg:pl-10 lg:prose-lg dark:prose-invert">{item.content}</p>
           </li>
         ))}
       </ul>

--- a/src/blocks/OptimizedImage/Component.tsx
+++ b/src/blocks/OptimizedImage/Component.tsx
@@ -5,6 +5,7 @@ export const OptimizedImageBlock: React.FC<OptimizedImageBlockProps> = ({
   image,
   height,
   width,
+  centerImage,
   priority,
   placeholder,
 }) => {
@@ -15,6 +16,7 @@ export const OptimizedImageBlock: React.FC<OptimizedImageBlockProps> = ({
       width={width}
       priority={priority}
       placeholder={placeholder ? 'blur' : 'empty'}
+      className={centerImage ? '[&>picture>img]:mx-auto' : undefined}
     />
   );
 };

--- a/src/blocks/OptimizedImage/config.ts
+++ b/src/blocks/OptimizedImage/config.ts
@@ -46,28 +46,33 @@ export const OptimizedImage: Block = {
       ],
     },
     {
-      type: 'row',
-      fields: [
-        {
-          name: 'priority',
-          type: 'checkbox',
-          label: 'Enable Priority',
-          admin: {
-            description:
-              'Enabling this option will prioritize the loading of this image. This should only be used for "above the fold" images.',
-          },
-        },
-        {
-          name: 'placeholder',
-          type: 'checkbox',
-          label: 'Enable Placeholder',
-          defaultValue: true,
-          admin: {
-            description:
-              'Enabling this option will display a low-quality blurred image placeholder while the full image loads.',
-          },
-        },
-      ],
+      name: 'centerImage',
+      type: 'checkbox',
+      label: 'Center Image',
+      defaultValue: false,
+      admin: {
+        description:
+          'Enabling this option will add automatic margins to center the image within its container.',
+      },
+    },
+    {
+      name: 'priority',
+      type: 'checkbox',
+      label: 'Enable Priority',
+      admin: {
+        description:
+          'Enabling this option will prioritize the loading of this image. This should only be used for "above the fold" images.',
+      },
+    },
+    {
+      name: 'placeholder',
+      type: 'checkbox',
+      label: 'Enable Placeholder',
+      defaultValue: true,
+      admin: {
+        description:
+          'Enabling this option will display a low-quality blurred image placeholder while the full image loads.',
+      },
     },
   ],
 };

--- a/src/blocks/Section/blocks/SectionColumns/Component.tsx
+++ b/src/blocks/Section/blocks/SectionColumns/Component.tsx
@@ -13,6 +13,10 @@ export type SectionColumnsBlockProps = BaseSectionColumnsBlockProps & {
   searchParams?: Record<string, string | string[] | undefined>;
 };
 
+type ColumnWidthOption = 'thirty' | 'forty' | 'fifty' | 'sixty' | 'seventy';
+
+const widthOptions: ColumnWidthOption[] = ['thirty', 'forty', 'fifty', 'sixty', 'seventy'];
+
 const columnBlockComponents = {
   cmsButton: CMSButtonBlock,
   collectionList: CollectionListBlock,
@@ -23,9 +27,8 @@ const columnBlockComponents = {
   sectionTitle: SectionTitleBlock,
 };
 
-// TODO: Does the breakpoint for desktop need to be 2xl instead of xl?
 const columnStyleVariants = cva(
-  'group-[.content-width-normal]/section:max-w-section-content group-[.content-width-wide]/section:max-w-section-wide-content flex flex-col items-center md:items-start gap-8 group is-columns',
+  'flex flex-col items-center mx-auto md:w-full md:mx-0 md:basis-0 md:min-w-0 md:items-start gap-8 group is-columns',
   {
     variants: {
       visibility: {
@@ -33,11 +36,36 @@ const columnStyleVariants = cva(
         tablet: 'hidden lg:block',
         desktop: 'hidden xl:block',
       },
+      width: {
+        thirty: 'md:flex-3', // 30 => 3 / (7 + 3) = 30%
+        forty: 'md:flex-2', // 40 => 2 / (3 + 2) = 40%
+        fifty: 'md:flex-1', // 50 => 1 / (1 + 1) = 50%
+        sixty: 'md:flex-3', // 60 => 3 / (2 + 3) = 60%
+        seventy: 'md:flex-7', // 70 => 7 / (7 + 3) = 70%
+      },
     },
   },
 );
 
+const breakoutWidths = (
+  widths: SectionColumnsBlockProps['widths'],
+): { first: ColumnWidthOption; second: ColumnWidthOption } => {
+  let [first, second] = (widths || '').split('-');
+
+  if (
+    !widthOptions.includes(first as ColumnWidthOption) ||
+    !widthOptions.includes(second as ColumnWidthOption)
+  ) {
+    first = 'fifty';
+    second = 'fifty';
+  }
+
+  return { first, second } as { first: ColumnWidthOption; second: ColumnWidthOption };
+};
+
 export const SectionColumnsBlock: React.FC<SectionColumnsBlockProps> = ({
+  widths,
+  stackAt,
   vertAlign,
   colOne,
   colTwo,
@@ -48,21 +76,27 @@ export const SectionColumnsBlock: React.FC<SectionColumnsBlockProps> = ({
   const colTwoHasBlocks =
     colTwo?.colBlocks && Array.isArray(colTwo.colBlocks) && colTwo.colBlocks.length > 0;
   const hasColumns = colOneHasBlocks || colTwoHasBlocks;
+  const columnWidths = breakoutWidths(widths);
 
   if (hasColumns) {
     return (
       <div
-        className={cn(
-          'flex flex-wrap justify-between group-[.content-width-wide]/section:gap-8 xl:group-[.content-width-wide]/section:gap-32',
-          {
-            'items-start': vertAlign === 'top',
-            'items-center': vertAlign === 'center',
-            'items-end': vertAlign === 'bottom',
-          },
-        )}
+        className={cn('flex flex-wrap group-[.content-width-wide]/section:gap-8', {
+          'items-start': vertAlign === 'top',
+          'items-center': vertAlign === 'center',
+          'items-end': vertAlign === 'bottom',
+          'flex-col md:flex-row': stackAt === 'mobile',
+          'flex-col lg:flex-row': stackAt === 'tablet',
+          'flex-col': stackAt === 'desktop',
+        })}
       >
         {colOneHasBlocks && (
-          <div className={columnStyleVariants({ visibility: colOne.visibility })}>
+          <div
+            className={columnStyleVariants({
+              visibility: colOne.visibility,
+              width: columnWidths.first,
+            })}
+          >
             {colOne.colBlocks?.map((block) => {
               const { blockType } = block;
 
@@ -79,7 +113,12 @@ export const SectionColumnsBlock: React.FC<SectionColumnsBlockProps> = ({
           </div>
         )}
         {colTwoHasBlocks && (
-          <div className={columnStyleVariants({ visibility: colTwo.visibility })}>
+          <div
+            className={columnStyleVariants({
+              visibility: colTwo.visibility,
+              width: columnWidths.second,
+            })}
+          >
             {colTwo.colBlocks?.map((block) => {
               const { blockType } = block;
 

--- a/src/blocks/Section/blocks/SectionColumns/config.ts
+++ b/src/blocks/Section/blocks/SectionColumns/config.ts
@@ -58,6 +58,46 @@ export const SectionColumns: Block = {
   },
   fields: [
     {
+      type: 'row',
+      fields: [
+        {
+          name: 'widths',
+          label: 'Column Widths',
+          type: 'select',
+          required: true,
+          defaultValue: 'fifty-fifty',
+          options: [
+            { label: '30 / 70', value: 'thirty-seventy' },
+            { label: '40 / 60', value: 'forty-sixty' },
+            { label: '50 / 50', value: 'fifty-fifty' },
+            { label: '60 / 40', value: 'sixty-forty' },
+            { label: '70 / 30', value: 'seventy-thirty' },
+          ],
+          admin: {
+            isClearable: false,
+            description:
+              'Columns will take the full width of the page when stacked on small screens.',
+          },
+        },
+        {
+          name: 'stackAt',
+          label: 'Stack Columns On',
+          type: 'select',
+          required: true,
+          defaultValue: 'mobile',
+          options: [
+            { label: 'Mobile', value: 'mobile' },
+            { label: 'Tablet', value: 'tablet' },
+            { label: 'Desktop', value: 'desktop' },
+          ],
+          admin: {
+            isClearable: false,
+            description: 'Columns will stack on the selected breakpoint and smaller.',
+          },
+        },
+      ],
+    },
+    {
       name: 'vertAlign',
       label: 'Vertical Alignment',
       type: 'select',
@@ -84,6 +124,7 @@ export const SectionColumns: Block = {
           fields: [...columnField],
           admin: {
             width: '50%',
+            hideGutter: true,
           },
         },
         {
@@ -93,6 +134,7 @@ export const SectionColumns: Block = {
           fields: [...columnField],
           admin: {
             width: '50%',
+            hideGutter: true,
           },
         },
       ],

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1314,6 +1314,10 @@ export interface OptimizedImageBlock {
   width?: number | null;
   height?: number | null;
   /**
+   * Enabling this option will add automatic margins to center the image within its container.
+   */
+  centerImage?: boolean | null;
+  /**
    * Enabling this option will prioritize the loading of this image. This should only be used for "above the fold" images.
    */
   priority?: boolean | null;

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1358,6 +1358,14 @@ export interface RelatedCardsBlock {
  */
 export interface SectionColumnsBlock {
   /**
+   * Columns will take the full width of the page when stacked on small screens.
+   */
+  widths: 'thirty-seventy' | 'forty-sixty' | 'fifty-fifty' | 'sixty-forty' | 'seventy-thirty';
+  /**
+   * Columns will stack on the selected breakpoint and smaller.
+   */
+  stackAt: 'mobile' | 'tablet' | 'desktop';
+  /**
    * This setting determines how columns with different heights are aligned vertically.
    */
   vertAlign: 'top' | 'center' | 'bottom';


### PR DESCRIPTION
- adds the ability to select column width relationships (70/30, 60/40, 50/50, 40/60, 30/70)
- adds the ability to adjust the breakpoint where columns stack
- adds the ability to horizontally center an optimized image
- fixes max content width on emphasized lists by adding `prose` to the content