### PR TITLE
fix(block): filter section column width

### DIFF
--- a/src/blocks/Section/blocks/SectionColumns/Component.tsx
+++ b/src/blocks/Section/blocks/SectionColumns/Component.tsx
@@ -28,7 +28,7 @@ const columnBlockComponents = {
 };
 
 const columnStyleVariants = cva(
-  'flex flex-col items-center mx-auto md:w-full md:mx-0 md:basis-0 md:min-w-0 md:items-start gap-8 group is-columns',
+  'flex flex-col items-center mx-auto md:mx-0 md:basis-0 md:min-w-0 md:items-start gap-8 group is-columns',
   {
     variants: {
       visibility: {
@@ -86,7 +86,7 @@ export const SectionColumnsBlock: React.FC<SectionColumnsBlockProps> = ({
           'items-center': vertAlign === 'center',
           'items-end': vertAlign === 'bottom',
           'flex-col md:flex-row': stackAt === 'mobile',
-          'flex-col lg:flex-row': stackAt === 'tablet',
+          'flex-col xl:flex-row': stackAt === 'tablet',
           'flex-col': stackAt === 'desktop',
         })}
       >

--- a/src/blocks/Section/blocks/SectionColumns/config.ts
+++ b/src/blocks/Section/blocks/SectionColumns/config.ts
@@ -1,4 +1,29 @@
-import { Block, Field } from 'payload';
+import { SectionBlock } from '@/payload-types';
+import { Block, Field, OptionObject } from 'payload';
+import { SectionWidths } from '../../types';
+
+// We're creating a placeholder for the page layout type
+// in case we allow the section block to be used in other
+// parent types.
+type LayoutBlocks = {
+  layout?: {
+    blocks?: SectionBlock[] | null;
+  };
+};
+
+const columnWidthOptions: OptionObject[] = [
+  { label: '30 / 70', value: 'thirty-seventy' },
+  { label: '40 / 60', value: 'forty-sixty' },
+  { label: '50 / 50', value: 'fifty-fifty' },
+  { label: '60 / 40', value: 'sixty-forty' },
+  { label: '70 / 30', value: 'seventy-thirty' },
+];
+
+const columnWidthFiltersBySectionWidth: Record<SectionWidths, string[]> = {
+  narrow: ['fifty-fifty', 'sixty-forty', 'forty-sixty'],
+  normal: columnWidthOptions.map(({ value }) => value),
+  wide: columnWidthOptions.map(({ value }) => value),
+};
 
 const columnField: Field[] = [
   {
@@ -66,13 +91,39 @@ export const SectionColumns: Block = {
           type: 'select',
           required: true,
           defaultValue: 'fifty-fifty',
-          options: [
-            { label: '30 / 70', value: 'thirty-seventy' },
-            { label: '40 / 60', value: 'forty-sixty' },
-            { label: '50 / 50', value: 'fifty-fifty' },
-            { label: '60 / 40', value: 'sixty-forty' },
-            { label: '70 / 30', value: 'seventy-thirty' },
-          ],
+          options: columnWidthOptions,
+          filterOptions: ({ siblingData, data }) => {
+            const currentBlockId = (siblingData as { id?: string | null } | undefined)?.id;
+            const layoutBlocks = (data as LayoutBlocks | undefined)?.layout?.blocks ?? [];
+
+            if (!currentBlockId || !layoutBlocks.length) {
+              return columnWidthOptions;
+            }
+
+            const parentSection = layoutBlocks.find(
+              (layoutBlock) =>
+                layoutBlock.blockType === 'section' &&
+                layoutBlock.sectionBlocks?.some(
+                  (sectionBlock) => sectionBlock.id === currentBlockId,
+                ),
+            );
+
+            const parentContentWidth = parentSection?.contentWidth;
+
+            if (!parentContentWidth) {
+              return columnWidthOptions;
+            }
+
+            const allowedOptionValues = columnWidthFiltersBySectionWidth[parentContentWidth];
+
+            if (!allowedOptionValues?.length) {
+              return columnWidthOptions;
+            }
+
+            return columnWidthOptions.filter((option) =>
+              allowedOptionValues.includes(option.value),
+            );
+          },
           admin: {
             isClearable: false,
             description:

--- a/src/blocks/Section/blocks/SectionColumns/config.ts
+++ b/src/blocks/Section/blocks/SectionColumns/config.ts
@@ -20,8 +20,10 @@ const columnWidthOptions: OptionObject[] = [
 ];
 
 const columnWidthFiltersBySectionWidth: Record<SectionWidths, string[]> = {
-  narrow: ['fifty-fifty', 'sixty-forty', 'forty-sixty'],
-  normal: columnWidthOptions.map(({ value }) => value),
+  // We don't allow columns on narrow sections, but if we did,
+  // this would be the only option that works well in a narrow content area.
+  narrow: ['fifty-fifty'],
+  normal: ['forty-sixty', 'fifty-fifty', 'sixty-forty'],
   wide: columnWidthOptions.map(({ value }) => value),
 };
 

--- a/src/blocks/Section/types.ts
+++ b/src/blocks/Section/types.ts
@@ -12,12 +12,10 @@ import {
   SectionContentBlock,
   SectionTitleBlock,
 } from '@/payload-types';
-
-// Helper type for options
-type Options = { label: string; value: string };
+import { OptionObject } from 'payload';
 
 export type SectionWidths = 'narrow' | 'normal' | 'wide';
-export type SectionWidthOptions = Record<SectionWidths, Options>;
+export type SectionWidthOptions = Record<SectionWidths, OptionObject>;
 
 type SectionBlocks =
   | CMSButtonBlock


### PR DESCRIPTION
- add filters to column options based on parent section width
- increase screen size for stacking on tablet for better content centering
- remove old full width for columns to fix centering on small screens