### PR TITLE
feat(page): sub-fund past meeting pagination

### DIFF
--- a/src/app/(frontend)/sub-funds/[slug]/page.client.tsx
+++ b/src/app/(frontend)/sub-funds/[slug]/page.client.tsx
@@ -7,23 +7,23 @@ import {
   EventTileHeader,
   EventTileNoEvents,
 } from '@/components/EventTile';
-import { EventTileData } from '@/components/EventTile/types';
-import MeetingMaterialsList from '@/components/MeetingMaterialsList';
-import { MeetingMaterialsData } from '@/components/MeetingMaterialsList/types';
+import type { EventTileData } from '@/components/EventTile/types';
+import { MeetingMaterialsList } from '@/components/MeetingMaterialsList';
 import ResourceList from '@/components/ResourceList';
 import { RichText } from '@/components/RichText';
 import TitleTheme from '@/components/TitleTheme';
-import { Subfund } from '@/payload-types';
+import type { Event, Subfund } from '@/payload-types';
 import { useHeaderTheme } from '@/providers/HeaderThemeProvider';
 import { cn } from '@/utilities/cn';
 import coolifyImageLoader from '@/utilities/coolifyImageLoader';
 import Image from 'next/image';
+import type { PaginatedDocs } from 'payload';
 import { useEffect } from 'react';
 
 type SubfundPageClientProps = {
   subfund: Subfund;
   upcomingEvents: EventTileData[];
-  pastMeetings: MeetingMaterialsData[];
+  pastMeetings: PaginatedDocs<Event> | null;
 };
 
 const SubfundPageClient: React.FC<SubfundPageClientProps> = ({
@@ -133,7 +133,7 @@ const SubfundPageClient: React.FC<SubfundPageClientProps> = ({
         </section>
       )}
       {/* Sub-fund Meetings */}
-      {pastMeetings.length > 0 && (
+      {pastMeetings?.totalDocs && pastMeetings.totalDocs > 0 && (
         <section className="px-4 py-12 lg:px-6 flex items-center justify-center">
           <div className="w-full max-w-section flex flex-col gap-8">
             <TitleTheme size="responsive" animated={true} className="mr-auto">

--- a/src/app/(frontend)/sub-funds/[slug]/page.tsx
+++ b/src/app/(frontend)/sub-funds/[slug]/page.tsx
@@ -1,20 +1,26 @@
-import { EventTileData } from '@/components/EventTile/types';
+import type { EventTileData } from '@/components/EventTile/types';
 import { LivePreviewListener } from '@/components/LivePreviewListener';
-import { MeetingMaterialsData } from '@/components/MeetingMaterialsList/types';
-import { Event, EventCategory } from '@/payload-types';
+import type { Event, EventCategory } from '@/payload-types';
 import { generateSubfundMetaGraph } from '@/utilities/generateSubfundMetaGraph';
 import configPromise from '@payload-config';
 import { Metadata } from 'next';
 import { draftMode } from 'next/headers';
 import { redirect } from 'next/navigation';
-import { getPayload, Where } from 'payload';
+import { getPayload, PaginatedDocs, Where } from 'payload';
 import { cache } from 'react';
 import SubfundPageClient from './page.client';
 
 type Args = {
   params: Promise<{ slug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
+/**
+ * Query the subfund by its slug from the Payload CMS.
+ *
+ * @param slug - The slug of the subfund to query.
+ * @returns The subfund document if found, otherwise null.
+ */
 const querySubfundBySlug = cache(async ({ slug }: { slug: string }) => {
   const { isEnabled: draft } = await draftMode();
   const payload = await getPayload({ config: configPromise });
@@ -33,6 +39,12 @@ const querySubfundBySlug = cache(async ({ slug }: { slug: string }) => {
   return result.docs?.[0] || null;
 });
 
+/**
+ * Query upcoming events by their categories from the Payload CMS.
+ *
+ * @param categories - The categories to filter events by.
+ * @returns An array of upcoming event data.
+ */
 const queryEventsByCategory = cache(
   async ({ categories }: { categories: Event['categories'] }): Promise<EventTileData[]> => {
     if (!categories || !Array.isArray(categories) || categories.length === 0) {
@@ -85,10 +97,22 @@ const queryEventsByCategory = cache(
   },
 );
 
+/**
+ * Query past meetings by their categories from the Payload CMS.
+ *
+ * @param categories - The categories to filter past meetings by.
+ * @returns An array of past meeting data.
+ */
 const queryPastMeetingsByCategory = cache(
-  async ({ categories }: { categories: Event['categories'] }): Promise<MeetingMaterialsData[]> => {
+  async ({
+    categories,
+    searchParams,
+  }: {
+    categories: Event['categories'];
+    searchParams?: Record<string, string | string[] | undefined>;
+  }): Promise<PaginatedDocs<Event> | null> => {
     if (!categories || !Array.isArray(categories) || categories.length === 0) {
-      return [];
+      return null;
     }
 
     const { isEnabled: draft } = await draftMode();
@@ -124,12 +148,22 @@ const queryPastMeetingsByCategory = cache(
       ],
     };
 
+    const perPageParam = searchParams?.perPage;
+    const pageParam = searchParams?.page;
+
+    const limit = Math.max(
+      1,
+      Number(Array.isArray(perPageParam) ? perPageParam[0] : perPageParam) || 5,
+    );
+    const page = Math.max(1, Number(Array.isArray(pageParam) ? pageParam[0] : pageParam) || 1);
+
     const result = await payload.find({
       collection: 'events',
       draft,
-      limit: 5,
-      pagination: false,
+      pagination: true,
       where,
+      limit: limit,
+      page: page,
       depth: 1,
       select: {
         id: true,
@@ -143,7 +177,7 @@ const queryPastMeetingsByCategory = cache(
       sort: '-startDate',
     });
 
-    return result.docs || [];
+    return result;
   },
 );
 
@@ -163,9 +197,13 @@ export async function generateMetadata({ params: paramsPromise }: Args): Promise
  * If the subfund does not exist, it redirects to the subfunds page.
  * If the subfund exists, it renders the subfund page with the subfund data.
  */
-export default async function SubfundPage({ params: paramsPromise }: Args) {
+export default async function SubfundPage({
+  params: paramsPromise,
+  searchParams: searchParamsPromise,
+}: Args) {
   const { isEnabled: draft } = await draftMode();
   const { slug } = await paramsPromise;
+  const searchParams = await searchParamsPromise;
   const subfund = await querySubfundBySlug({ slug });
 
   if (!subfund) {
@@ -178,6 +216,7 @@ export default async function SubfundPage({ params: paramsPromise }: Args) {
 
   const pastMeetings = await queryPastMeetingsByCategory({
     categories: subfund.content.pastMeetingsFilters,
+    searchParams,
   });
 
   return (

--- a/src/app/(frontend)/sub-funds/[slug]/page.tsx
+++ b/src/app/(frontend)/sub-funds/[slug]/page.tsx
@@ -151,10 +151,9 @@ const queryPastMeetingsByCategory = cache(
     const perPageParam = searchParams?.perPage;
     const pageParam = searchParams?.page;
 
-    const limit = Math.max(
-      1,
-      Number(Array.isArray(perPageParam) ? perPageParam[0] : perPageParam) || 5,
-    );
+    const requestedLimit =
+      Number(Array.isArray(perPageParam) ? perPageParam[0] : perPageParam) || 5;
+    const limit = Math.max(1, Math.max(requestedLimit, 5));
     const page = Math.max(1, Number(Array.isArray(pageParam) ? pageParam[0] : pageParam) || 1);
 
     const result = await payload.find({

--- a/src/blocks/CollectionList/components/CollectionListEvents/Component.client.tsx
+++ b/src/blocks/CollectionList/components/CollectionListEvents/Component.client.tsx
@@ -2,10 +2,10 @@
 
 import EventCard from '@/components/EventCard';
 import { EventCardTemplates } from '@/components/EventCard/types';
+import { Pagination } from '@/components/Pagination';
 import { Event } from '@/payload-types';
 import { PaginatedDocs } from 'payload';
 import { useRef } from 'react';
-import { CollectionListPageControl } from '../CollectionListPageControl';
 import { CollectionListEventsProps } from './Component';
 
 type CollectionListEventsClientProps = CollectionListEventsProps & {
@@ -20,9 +20,7 @@ export const CollectionListEventsClient: React.FC<CollectionListEventsClientProp
 
   return events && events.docs.length ? (
     <div ref={blockTopRef}>
-      {filters?.pagination && (
-        <CollectionListPageControl totalDocs={events.totalDocs} className="mb-4" />
-      )}
+      {filters?.pagination && <Pagination totalDocs={events.totalDocs} className="mb-4" />}
       <div className="space-y-4">
         {events.docs.map((event) => (
           <EventCard
@@ -35,7 +33,7 @@ export const CollectionListEventsClient: React.FC<CollectionListEventsClientProp
         ))}
       </div>
       {filters?.pagination && (
-        <CollectionListPageControl
+        <Pagination
           totalDocs={events.totalDocs}
           className="mt-4"
           scrollToTopTargetRef={blockTopRef}

--- a/src/blocks/CollectionList/components/CollectionListLegalNotices/Component.client.tsx
+++ b/src/blocks/CollectionList/components/CollectionListLegalNotices/Component.client.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { LegalNoticeCard } from '@/components/LegalNoticeCard';
+import { Pagination } from '@/components/Pagination';
 import { LegalNotice } from '@/payload-types';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { PaginatedDocs } from 'payload';
 import { useEffect, useRef } from 'react';
-import { CollectionListPageControl } from '../CollectionListPageControl';
 import { CollectionListLegalNoticesProps } from './Component';
 
 type CollectionListLegalNoticesClientProps = CollectionListLegalNoticesProps & {
@@ -36,16 +36,14 @@ export const CollectionListLegalNoticesClient: React.FC<CollectionListLegalNotic
 
   return notices && notices.docs.length ? (
     <div ref={blockTopRef}>
-      {filters?.pagination && (
-        <CollectionListPageControl totalDocs={notices.totalDocs} className="mb-4" />
-      )}
+      {filters?.pagination && <Pagination totalDocs={notices.totalDocs} className="mb-4" />}
       <div className="space-y-4">
         {notices.docs.map((notice) => (
           <LegalNoticeCard key={notice.id} {...notice} />
         ))}
       </div>
       {filters?.pagination && (
-        <CollectionListPageControl
+        <Pagination
           totalDocs={notices.totalDocs}
           className="mt-4"
           scrollToTopTargetRef={blockTopRef}

--- a/src/components/MeetingMaterialsList/components/MeetingHeader/index.tsx
+++ b/src/components/MeetingMaterialsList/components/MeetingHeader/index.tsx
@@ -19,7 +19,7 @@ export const MeetingHeader: React.FC<{ meeting: MeetingMaterialsData }> = ({ mee
   const resourceCountLabel =
     resourceCount <= 0 ? 'No Items' : resourceCount > 1 ? `${resourceCount} Items` : '1 Item';
 
-  const meetingTitleRef = useRef(null);
+  const meetingTitleRef = useRef<HTMLHeadingElement | null>(null);
   const { isTruncated } = useIsTruncated({ elementRef: meetingTitleRef });
 
   return (

--- a/src/components/MeetingMaterialsList/components/MeetingHeader/index.tsx
+++ b/src/components/MeetingMaterialsList/components/MeetingHeader/index.tsx
@@ -1,0 +1,54 @@
+import { useHasHydrated } from '@/components/hooks/useHasHydrated';
+import { useIsTruncated } from '@/components/hooks/useIsTruncated';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/primitives/ui/tooltip';
+import { useRef } from 'react';
+import { MeetingMaterialsData } from '../../types';
+
+export const MeetingHeader: React.FC<{ meeting: MeetingMaterialsData }> = ({ meeting }) => {
+  const hydrated = useHasHydrated();
+
+  const startDate = hydrated && typeof meeting === 'object' ? new Date(meeting.startDate) : null;
+
+  const formattedDate = startDate
+    ? new Intl.DateTimeFormat('en-US', { month: 'long', day: '2-digit', year: 'numeric' }).format(
+        startDate,
+      )
+    : undefined;
+
+  const resourceCount = meeting.resources?.length || 0;
+  const resourceCountLabel =
+    resourceCount <= 0 ? 'No Items' : resourceCount > 1 ? `${resourceCount} Items` : '1 Item';
+
+  const meetingTitleRef = useRef(null);
+  const { isTruncated } = useIsTruncated({ elementRef: meetingTitleRef });
+
+  return (
+    <div className="flex items-center gap-4 w-full">
+      <Tooltip>
+        <TooltipTrigger asChild disabled={resourceCount === 0}>
+          <div className="grow overflow-hidden">
+            {formattedDate ? (
+              <small className="text-sm text-foreground-muted">{formattedDate}</small>
+            ) : (
+              <small className="text-sm text-foreground-muted">
+                <span className="inline-block h-4 w-36 rounded bg-foreground/10 align-middle animate-pulse" />
+              </small>
+            )}
+            <h4
+              className="text-lg font-bold whitespace-nowrap overflow-hidden text-ellipsis"
+              ref={meetingTitleRef}
+            >
+              {meeting.title}
+            </h4>
+          </div>
+        </TooltipTrigger>
+        {isTruncated && <TooltipContent>{meeting.title}</TooltipContent>}
+      </Tooltip>
+      <div className="flex items-center gap-4">
+        <small className="text-sm font-medium text-(--subfund-foreground)">
+          {resourceCountLabel}
+        </small>
+      </div>
+    </div>
+  );
+};

--- a/src/components/MeetingMaterialsList/index.tsx
+++ b/src/components/MeetingMaterialsList/index.tsx
@@ -34,7 +34,7 @@ export const MeetingMaterialsList: React.FC<MeetingMaterialsListProps> = ({
   }, [meetings?.docs.length, pathname, router, searchParams]);
 
   return (
-    <div className={className}>
+    <div className={className} ref={blockTopRef}>
       <Accordion type="multiple">
         {meetings.docs.map((meeting) => (
           <AccordionItem key={meeting.id} value={meeting.title}>

--- a/src/components/MeetingMaterialsList/index.tsx
+++ b/src/components/MeetingMaterialsList/index.tsx
@@ -35,7 +35,7 @@ export const MeetingMaterialsList: React.FC<MeetingMaterialsListProps> = ({
 
   return (
     <div className={className} ref={blockTopRef}>
-      <Accordion type="multiple">
+      <Accordion type="single" collapsible>
         {meetings.docs.map((meeting) => (
           <AccordionItem key={meeting.id} value={meeting.title}>
             <AccordionTrigger>
@@ -53,7 +53,7 @@ export const MeetingMaterialsList: React.FC<MeetingMaterialsListProps> = ({
         defaultPageSize={5}
         className="mt-4"
         scrollToTopTargetRef={blockTopRef}
-        scrollToTopOffset={48}
+        scrollToTopOffset={94}
       />
     </div>
   );

--- a/src/components/MeetingMaterialsList/index.tsx
+++ b/src/components/MeetingMaterialsList/index.tsx
@@ -1,80 +1,60 @@
+import ResourceList from '@/components/ResourceList';
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
 } from '@/primitives/ui/accordion';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/primitives/ui/tooltip';
-import { useRef } from 'react';
-import { useHasHydrated } from '../hooks/useHasHydrated';
-import { useIsTruncated } from '../hooks/useIsTruncated';
-import ResourceList from '../ResourceList';
-import { MeetingMaterialsData, MeetingMaterialsListProps } from './types';
+import { usePathname, useRouter, useSearchParams } from 'next/dist/client/components/navigation';
+import { useEffect, useRef } from 'react';
+import { Pagination } from '../Pagination';
+import { MeetingHeader } from './components/MeetingHeader';
+import { MeetingMaterialsListProps } from './types';
 
-const MeetingMaterialsList: React.FC<MeetingMaterialsListProps> = ({ meetings, className }) => {
-  return (
-    <Accordion type="multiple" className={className}>
-      {meetings?.map((meeting) => (
-        <AccordionItem key={meeting.id} value={meeting.title}>
-          <AccordionTrigger>
-            <MeetingHeader meeting={meeting} />
-          </AccordionTrigger>
-          <AccordionContent>
-            <ResourceList resources={meeting.resources} nested />
-          </AccordionContent>
-        </AccordionItem>
-      ))}
-    </Accordion>
-  );
-};
+export const MeetingMaterialsList: React.FC<MeetingMaterialsListProps> = ({
+  meetings,
+  className,
+}) => {
+  const blockTopRef = useRef<HTMLDivElement>(null);
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
 
-const MeetingHeader: React.FC<{ meeting: MeetingMaterialsData }> = ({ meeting }) => {
-  const hydrated = useHasHydrated();
+  useEffect(() => {
+    const currentPageParam = searchParams?.get('page');
+    const currentPerPageParam = searchParams?.get('perPage');
+    const hasPaginationParams = currentPageParam !== null || currentPerPageParam !== null;
+    const hasNoResults = meetings?.docs.length === 0;
 
-  const startDate = hydrated && typeof meeting === 'object' ? new Date(meeting.startDate) : null;
+    if (!hasPaginationParams || !hasNoResults) {
+      return;
+    }
 
-  const formattedDate = startDate
-    ? new Intl.DateTimeFormat('en-US', { month: 'long', day: '2-digit', year: 'numeric' }).format(
-        startDate,
-      )
-    : undefined;
-
-  const resourceCount = meeting.resources?.length || 0;
-  const resourceCountLabel =
-    resourceCount <= 0 ? 'No Items' : resourceCount > 1 ? `${resourceCount} Items` : '1 Item';
-
-  const meetingTitleRef = useRef(null);
-  const { isTruncated } = useIsTruncated({ elementRef: meetingTitleRef });
+    router.replace(`${pathname}`);
+  }, [meetings?.docs.length, pathname, router, searchParams]);
 
   return (
-    <div className="flex items-center gap-4 w-full">
-      <Tooltip>
-        <TooltipTrigger asChild disabled={resourceCount === 0}>
-          <div className="grow overflow-hidden">
-            {formattedDate ? (
-              <small className="text-sm text-foreground-muted">{formattedDate}</small>
-            ) : (
-              <small className="text-sm text-foreground-muted">
-                <span className="inline-block h-4 w-36 rounded bg-foreground/10 align-middle animate-pulse" />
-              </small>
-            )}
-            <h4
-              className="text-lg font-bold whitespace-nowrap overflow-hidden text-ellipsis"
-              ref={meetingTitleRef}
-            >
-              {meeting.title}
-            </h4>
-          </div>
-        </TooltipTrigger>
-        {isTruncated && <TooltipContent>{meeting.title}</TooltipContent>}
-      </Tooltip>
-      <div className="flex items-center gap-4">
-        <small className="text-sm font-medium text-(--subfund-foreground)">
-          {resourceCountLabel}
-        </small>
-      </div>
+    <div className={className}>
+      <Accordion type="multiple">
+        {meetings.docs.map((meeting) => (
+          <AccordionItem key={meeting.id} value={meeting.title}>
+            <AccordionTrigger>
+              <MeetingHeader meeting={meeting} />
+            </AccordionTrigger>
+            <AccordionContent>
+              <ResourceList resources={meeting.resources} nested />
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+      <Pagination
+        totalDocs={meetings.totalDocs}
+        pageSizes={[5]}
+        defaultPageSize={5}
+        className="mt-4"
+        scrollToTopTargetRef={blockTopRef}
+        scrollToTopOffset={48}
+      />
     </div>
   );
 };
-
-export default MeetingMaterialsList;

--- a/src/components/MeetingMaterialsList/index.tsx
+++ b/src/components/MeetingMaterialsList/index.tsx
@@ -5,7 +5,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@/primitives/ui/accordion';
-import { usePathname, useRouter, useSearchParams } from 'next/dist/client/components/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { Pagination } from '../Pagination';
 import { MeetingHeader } from './components/MeetingHeader';

--- a/src/components/MeetingMaterialsList/types.ts
+++ b/src/components/MeetingMaterialsList/types.ts
@@ -1,4 +1,5 @@
-import { RequiredDataFromCollectionSlug } from 'payload';
+import type { Event } from '@/payload-types';
+import { PaginatedDocs, RequiredDataFromCollectionSlug } from 'payload';
 
 export type MeetingMaterialsData = Pick<
   RequiredDataFromCollectionSlug<'events'>,
@@ -6,7 +7,7 @@ export type MeetingMaterialsData = Pick<
 >;
 
 export type MeetingMaterialsListProps = {
-  meetings?: MeetingMaterialsData[];
+  meetings: PaginatedDocs<Event>;
   className?: string;
 };
 

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -44,19 +44,35 @@ const parsePositiveInt = (value: string | null) => {
   return parsed;
 };
 
-export type CollectionListPageControlProps = {
+export type PaginationProps = {
   totalDocs: number;
+  pageSizes?: number[];
+  defaultPageSize?: number;
   className?: string;
   scrollToTopTargetRef?: RefObject<HTMLElement | null>;
   scrollToTopOffset?: number;
 };
 
-export const CollectionListPageControl: React.FC<CollectionListPageControlProps> = ({
+export const Pagination: React.FC<PaginationProps> = ({
   totalDocs,
+  pageSizes = PAGE_SIZES,
+  defaultPageSize = DEFAULT_PAGE_SIZE,
   className,
   scrollToTopTargetRef,
   scrollToTopOffset = 0,
 }) => {
+  // Validate the provided page sizes and default page size
+  if (pageSizes.length === 0 || !pageSizes.includes(defaultPageSize)) {
+    throw new Error(
+      'Pagination component requires at least one page size and the default page size must be included in the page sizes array.',
+    );
+  }
+
+  // If there are no documents, do not render the pagination component
+  if (totalDocs <= 0) {
+    return null;
+  }
+
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
@@ -65,7 +81,7 @@ export const CollectionListPageControl: React.FC<CollectionListPageControlProps>
   const reqPerPage = parsePositiveInt(searchParams?.get('perPage') || null);
 
   const perPage =
-    reqPerPage !== null && PAGE_SIZES.includes(reqPerPage) ? reqPerPage : DEFAULT_PAGE_SIZE;
+    reqPerPage !== null && pageSizes.includes(reqPerPage) ? reqPerPage : defaultPageSize;
   const totalPages = Math.max(1, Math.ceil(totalDocs / perPage));
   const page = reqPage !== null ? Math.min(Math.max(reqPage, 1), totalPages) : 1;
 
@@ -248,34 +264,40 @@ export const CollectionListPageControl: React.FC<CollectionListPageControlProps>
         />
         <span className="text-sm">of {totalPages}</span>
       </div>
-      <span className="text-sm text-foreground-muted"> | </span>
-      <Popover>
-        <PopoverTrigger className={cn(buttonVariants({ animation: 'bounceDown' }), BUTTON_VARIANT)}>
-          <span>{perPage} per page</span>
-          <ChevronDownIcon size={16} />
-        </PopoverTrigger>
-        <PopoverContent collisionPadding={16} className="w-14 p-1">
-          <div className="flex flex-col gap-2">
-            {PAGE_SIZES.map((size) => (
-              <Button
-                type="button"
-                style="ghost"
-                color="neutral"
-                size="small"
-                key={`pagesize-${size}`}
-                className={cn('border border-transparent', {
-                  'border-njsig-neutral-midtone bg-njsig-neutral-tint pointer-events-none':
-                    size === perPage,
-                })}
-                onClick={() => handlePageSizePick(size)}
-                aria-label={`${size} per page`}
-              >
-                {size}
-              </Button>
-            ))}
-          </div>
-        </PopoverContent>
-      </Popover>
+      {pageSizes.length > 1 && (
+        <>
+          <span className="text-sm text-foreground-muted"> | </span>
+          <Popover>
+            <PopoverTrigger
+              className={cn(buttonVariants({ animation: 'bounceDown' }), BUTTON_VARIANT)}
+            >
+              <span>{perPage} per page</span>
+              <ChevronDownIcon size={16} />
+            </PopoverTrigger>
+            <PopoverContent collisionPadding={16} className="w-14 p-1">
+              <div className="flex flex-col gap-2">
+                {pageSizes.map((size) => (
+                  <Button
+                    type="button"
+                    style="ghost"
+                    color="neutral"
+                    size="small"
+                    key={`pagesize-${size}`}
+                    className={cn('border border-transparent', {
+                      'border-njsig-neutral-midtone bg-njsig-neutral-tint pointer-events-none':
+                        size === perPage,
+                    })}
+                    onClick={() => handlePageSizePick(size)}
+                    aria-label={`${size} per page`}
+                  >
+                    {size}
+                  </Button>
+                ))}
+              </div>
+            </PopoverContent>
+          </Popover>
+        </>
+      )}
       <div className="flex items-center ml-auto gap-1.5">
         <Button
           className={cn(buttonVariants({ animation: 'bounceLeft' }), ICON_BUTTON_VARIANT)}

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -68,11 +68,6 @@ export const Pagination: React.FC<PaginationProps> = ({
     );
   }
 
-  // If there are no documents, do not render the pagination component
-  if (totalDocs <= 0) {
-    return null;
-  }
-
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
@@ -250,6 +245,12 @@ export const Pagination: React.FC<PaginationProps> = ({
     router,
     scrollToTopTarget,
   ]);
+
+  // If there are no documents, do not render the pagination component
+  // TODO: Can we bail out earlier in the render process to avoid unnecessary calculations and state updates?
+  if (totalDocs <= 0) {
+    return null;
+  }
 
   return (
     <div className={cn('flex items-center justify-center gap-2', className)}>

--- a/src/fields/DocumentConsumerTracking/schema.ts
+++ b/src/fields/DocumentConsumerTracking/schema.ts
@@ -32,6 +32,6 @@ export const schema: NonNullable<JSONField['jsonSchema']>['schema'] = {
         },
       },
     },
-    required: ['id', 'titleField', 'title', 'collectionSlug', 'instances'],
+    required: ['id', 'title', 'collectionSlug', 'instances'],
   },
 };

--- a/src/fields/DocumentConsumerTracking/tasks/createSyncDocumentConsumerTitles.ts
+++ b/src/fields/DocumentConsumerTracking/tasks/createSyncDocumentConsumerTitles.ts
@@ -115,7 +115,9 @@ export const createSyncDocumentConsumerTitles = <TSlug extends string>(
               }
 
               const consumerDocument = consumerDoc as unknown as ConsumerDocument;
-              const consumerTitle = String(consumerDocument[consumer.titleField] ?? consumerDoc.id);
+              const consumerTitle = String(
+                consumerDocument[consumer.titleField || 'title'] ?? consumerDoc.id,
+              );
 
               if (consumerTitle !== consumer.title) {
                 // Update the consumer title in the tracked document

--- a/src/fields/DocumentConsumerTracking/types.ts
+++ b/src/fields/DocumentConsumerTracking/types.ts
@@ -1,6 +1,6 @@
 export type DocumentConsumer = {
   id: string;
-  titleField: string;
+  titleField?: string;
   title: string;
   collectionSlug: string;
   instances: string[];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -17,7 +17,7 @@ export type Consumers = {
   /**
    * The field in the consumer document that is used as the title
    */
-  titleField: string;
+  titleField?: string;
   /**
    * The title of the consumer document
    */


### PR DESCRIPTION
fixes #93 

- breaks pagination into own component
- adds adjustable page sizes to pagination component
- updates sub-fund page and components for pagination
- makes `titleField` optional in document consumer to account for old data